### PR TITLE
Refill pressure grace period

### DIFF
--- a/app/lib/coffee_time/boiler/power_manager.ex
+++ b/app/lib/coffee_time/boiler/power_manager.ex
@@ -1,10 +1,21 @@
 defmodule CoffeeTime.Boiler.PowerManager do
   @moduledoc """
   Manages changing the desired temp
-  """
 
-  # I'm not 100% convinced this needs to be a dedicated process vs the temp control and duty
-  # cycle pids, but I'll sort that out at some point.
+  Roughly speaking the boiler operations in 3 power modes:
+
+  1) Sleep: It's asleep and there is no power
+  2) Idle: It's hot enough to be pressurized and make espresso, but is too low
+  for practical steaming
+  3) Active: Nice and hot for steaming.
+
+  Sleep is controlled via a schedule. You can also kick it out of sleep mode by
+  running any barista program or manually via the API.
+
+  Idle converts to active by flushing steam through the steam wand. You need to
+  do this anyway to flush condensate, so this tells the `PowerManager` that you
+  want steam.
+  """
 
   use GenStateMachine, callback_mode: [:handle_event_function, :state_enter]
   require Logger

--- a/app/lib/coffee_time/boiler/power_manager.ex
+++ b/app/lib/coffee_time/boiler/power_manager.ex
@@ -258,11 +258,11 @@ defmodule CoffeeTime.Boiler.PowerManager do
     __set_config__(data.context, new_config)
 
     reply = [
-      old: old_config[key],
-      new: new_config[key]
+      old: Map.fetch!(old_config, key),
+      new: Map.fetch!(new_config, key)
     ]
 
-    {:next_state, :sleep, data, {:reply, from, reply}}
+    {:repeat_state, data, {:reply, from, reply}}
   end
 
   def handle_event({:call, from}, :sleep, _, data) do

--- a/app/lib/coffee_time/boiler/power_manager/config.ex
+++ b/app/lib/coffee_time/boiler/power_manager/config.ex
@@ -4,5 +4,6 @@ defmodule CoffeeTime.Boiler.PowerManager.Config do
             sleep_pressure: 0,
             active_trigger_threshold: 0,
             active_duration: :infinity,
+            refill_grace_period: 0,
             power_saver_interval: nil
 end

--- a/app/lib/coffee_time/util.ex
+++ b/app/lib/coffee_time/util.ex
@@ -17,6 +17,24 @@ defmodule CoffeeTime.Util do
     Process.cancel_timer(ref)
   end
 
+  def cancel_self_timer(%{} = map, key) do
+    if timer = Map.fetch!(map, key) do
+      cancel_timer(timer)
+    end
+
+    %{map | key => nil}
+  end
+
+  def start_self_timer(%_{} = map, key, msg, timeout, opts \\ []) when is_atom(key) do
+    Map.update!(map, key, fn
+      nil ->
+        send_after(self(), msg, timeout, opts)
+
+      existing ->
+        existing
+    end)
+  end
+
   def receive_inspect_loop() do
     receive do
       x ->


### PR DESCRIPTION
Previously, when the steam boiler refilled while in the idle mode, the drop in pressure caused by the cold water added to the boiler was interpreted as the steam wand getting used. This introduces a grace period after refill during which pressure drops are ignored.